### PR TITLE
Fix Critical Updates and add download buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
   <div class="top-announcement" role="banner">
     <div class="top-announcement__inner">
       <div class="top-announcement__text">
-        <span class="top-announcement__label">Critical Update</span>
+        <span class="top-announcement__label">Critical Updates</span>
         <span class="top-announcement__message">
           <strong>DO NOT UPDATE!</strong> Amazon has released Firmware 5.18.6 which breaks adbreak!<br>
-          <a href="helpkindlemodshelf.html" style="color: inherit; text-decoration: underline;">Kindlemodshelf needs your help...</a>
+          <strong>kindlemodshelf needs your help!:</strong> <a href="helpkindlemodshelf.html" style="color: inherit; text-decoration: underline;">Learn how you can contribute</a>
         </span>
       </div>
       <button class="top-announcement__close" type="button" aria-label="Dismiss announcement">×</button>
@@ -117,7 +117,10 @@
         <div class="card-desc">
         Touch-friendly mod store that installs KOReader, scriptlets, and tweaks directly—no manual USB shuffling.
       </div>
-        <div class="card-links"><a href="kindleforge.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/KindleTweaks/KindleForge/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="kindleforge.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="koreader reader essential epub pdf cbz mobi plugin">
@@ -126,9 +129,12 @@
           <div class="card-tags"><span class="tag">Essential</span></div>
         </div>
         <div class="card-desc">
-        Free, open-source e-book reader with fast page turns, broad format support, and customization Amazon’s stock app can’t touch.
+        Free, open-source e-book reader with fast page turns, broad format support, and customization Amazon's stock app can't touch.
       </div>
-        <div class="card-links"><a href="koreader.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/koreader/koreader/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="koreader.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="shortcuts sh home screen launcher">
@@ -139,7 +145,10 @@
         <div class="card-desc">
         Drop desired <code>.sh</code> launcher scripts into <code>/mnt/us/documents</code>. Tap them on the Home screen to open apps directly—no KUAL required.
       </div>
-      <div class="card-links"><a href="shortcuts.html">More</a></div>
+      <div class="card-links">
+        <a href="shortcuts.html" class="card-download">Download</a>
+        <a href="shortcuts.html">More</a>
+      </div>
     </div>
 
       <div class="card" data-tags="kual installer essential tool peki">
@@ -150,7 +159,10 @@
         <div class="card-desc">
         Install and launch KUAL without MRPI while keeping a polished booklet icon and reliable hotfix-friendly workflow.
       </div>
-        <div class="card-links"><a href="peki.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/KindleTweaks/PEKI/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="peki.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="kterm terminal emulator shell essential">
@@ -161,7 +173,10 @@
         <div class="card-desc">
         The must-have terminal for jailbroken Kindles. Run shell scripts, install mods, and manage files directly on-device with an on-screen keyboard.
       </div>
-        <div class="card-links"><a href="kterm.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/bfabiszewski/kterm/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="kterm.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="disable ads screensaver script tool essential">
@@ -172,7 +187,10 @@
         <div class="card-desc">
         Enable KOReader custom screensavers (book covers or images) on ad-supported Kindles using a single script.
       </div>
-        <div class="card-links"><a href="disableads.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/disable_ads.sh" class="card-download" download>Download</a>
+          <a href="disableads.html">More</a>
+        </div>
     </div>
     </div>
 
@@ -187,7 +205,10 @@
         <div class="card-desc">
         Curated roundup of the most useful KOReader plugins—with quick summaries, download links, and setup notes for each add-on.
       </div>
-        <div class="card-links"><a href="plugins.html">More</a></div>
+        <div class="card-links">
+          <a href="plugins.html" class="card-download">Download</a>
+          <a href="plugins.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="telegram highlights plugin koreader">
@@ -198,7 +219,10 @@
         <div class="card-desc">
         Send Kindle highlights and screenshots to your Telegram account instantly via @bookshotsbot.
       </div>
-        <div class="card-links"><a href="telegram.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/0xmiki/telegramhighlights.koplugin/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="telegram.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="koweather weather plugin koreader">
@@ -209,7 +233,10 @@
         <div class="card-desc">
         Live weather forecasts inside KOReader—perfect before an outdoor reading session.
       </div>
-        <div class="card-links"><a href="koweather.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/roygbyte/weather.koplugin" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="koweather.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="clock plugin koreader dtDisplay">
@@ -220,7 +247,10 @@
         <div class="card-desc">
         Fullscreen clock widget (time &amp; date) for a clean e-ink desk or bedside clock while charging.
       </div>
-        <div class="card-links"><a href="koclock.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/kktse/dtdisplay.koplugin" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="koclock.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="projecttitle koreader plugin library covers ui">
@@ -231,7 +261,10 @@
         <div class="card-desc">
         Modern KOReader library view with cover-first browsing, progress badges, and gesture resizing—drop-in replacement for Cover Browser.
       </div>
-        <div class="card-links"><a href="projecttitle.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/joshuacant/ProjectTitle/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="projecttitle.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="koreader icons theme ui font projecttitle handdrawn">
@@ -240,9 +273,12 @@
           <div class="card-tags"><span class="tag">Theme</span></div>
         </div>
         <div class="card-desc">
-        Replace KOReader’s interface with hand-drawn icons and handwriting UI font, plus a ProjectTitle icon pack for cohesive styling.
+        Replace KOReader's interface with hand-drawn icons and handwriting UI font, plus a ProjectTitle icon pack for cohesive styling.
       </div>
-        <div class="card-links"><a href="icon.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/icons.zip" class="card-download" download>Download</a>
+          <a href="icon.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="koreader plugin parental controls time schedule timeblock">
@@ -253,7 +289,10 @@
         <div class="card-desc">
         KOReader Time Block limits when children can read in KOReader with customizable reading windows so kids can enjoy ebooks only during the times you approve.
       </div>
-        <div class="card-links"><a href="timeblock.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/timeblock.koplugin.zip" class="card-download" download>Download</a>
+          <a href="timeblock.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="koreader tool autostart boot kual">
@@ -264,7 +303,10 @@
         <div class="card-desc">
         Install a KUAL extension that toggles KOReader autolaunch scripts so the reader opens on boot while keeping the Kindle UI active.
       </div>
-        <div class="card-links"><a href="bootkoreader.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/meepcat55/Kindle-KOReader-On-Boot" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="bootkoreader.html">More</a>
+        </div>
     </div>
     </div>
 
@@ -279,7 +321,10 @@
         <div class="card-desc">
         Installation guide plus curated user patches—browser, UI, status bar, screensaver, and Project: Title extensions.
       </div>
-        <div class="card-links"><a href="patches.html">More</a></div>
+        <div class="card-links">
+          <a href="patches.html" class="card-download">Download</a>
+          <a href="patches.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="patches page header userpatch koreader typography small caps project title">
@@ -288,9 +333,12 @@
           <div class="card-tags"><span class="tag">Patch</span></div>
         </div>
         <div class="card-desc">
-        Fiction-style page header with per-book configuration—designed to complement Project: Title’s typography.
+        Fiction-style page header with per-book configuration—designed to complement Project: Title's typography.
       </div>
-        <div class="card-links"><a href="pageheader.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/2-page-header.lua" class="card-download" download>Download</a>
+          <a href="pageheader.html">More</a>
+        </div>
     </div>
     </div>
 
@@ -305,7 +353,10 @@
         <div class="card-desc">
         Play classic Tetris in the terminal on hardfloat-firmware Kindles. Lightweight—no emulator needed.
       </div>
-        <div class="card-links"><a href="tetris.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/kindletetris.zip" class="card-download" download>Download</a>
+          <a href="tetris.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="gnome chess minesweeper game strategy">
@@ -316,18 +367,24 @@
         <div class="card-desc">
         Touch-friendly ports of Gnome Chess and Minesweeper. Smooth, responsive gameplay on e-ink.
       </div>
-        <div class="card-links"><a href="gnomegames.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/crazy-electron/GnomeGames4Kindle/releases/latest/download/gnomegames.zip" class="card-download" target="_blank" rel="noopener" download>Download</a>
+          <a href="gnomegames.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="nine men's morris game kual kterm board strategy">
         <div class="card-header">
-          <div class="card-title">Nine Men’s Morris (SF &amp; HF)</div>
+          <div class="card-title">Nine Men's Morris (SF &amp; HF)</div>
           <div class="card-tags"><span class="tag">Game</span></div>
         </div>
         <div class="card-desc">
         Strategy board game in two editions: softfloat (launches from KUAL) or hardfloat (runs in KTerm).
       </div>
-        <div class="card-links"><a href="ninemensmorris.html">More</a></div>
+        <div class="card-links">
+          <a href="ninemensmorris.html" class="card-download">Download</a>
+          <a href="ninemensmorris.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="gargoyle interactive fiction game interpreter hf sf kindle">
@@ -338,7 +395,10 @@
         <div class="card-desc">
         Play Z-Machine, Glulx, TADS, and other interactive fiction formats on Kindle with dedicated HF and SF builds.
       </div>
-        <div class="card-links"><a href="gargoyle.html">More</a></div>
+        <div class="card-links">
+          <a href="gargoyle.html" class="card-download">Download</a>
+          <a href="gargoyle.html">More</a>
+        </div>
     </div>
 
     <div class="card" data-tags="ifdb interactive fiction game downloader kterm kual hf">
@@ -349,7 +409,10 @@
         <div class="card-desc">
         Native utility for HF Kindles to download interactive fiction games from IFDB and play them with Gargoyle.
       </div>
-        <div class="card-links"><a href="ifdb-dl.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/dfghjkjhgr/ifdb-dl/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="ifdb-dl.html">More</a>
+        </div>
     </div>
 
     <div class="card" data-tags="kwordle wordle game puzzle offline multilingual">
@@ -360,7 +423,10 @@
         <div class="card-desc">
         Offline Wordle-style puzzle for Kindle—multilingual word lists and e-ink-friendly visuals.
       </div>
-        <div class="card-links"><a href="kwordle.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/crizmo/KWordle" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="kwordle.html">More</a>
+        </div>
     </div>
 
     <div class="card" data-tags="universal paperclips idle clicker mesquite game">
@@ -371,7 +437,10 @@
         <div class="card-desc">
         Idle clicker classic as a Mesquite web app—play on any jailbroken Kindle.
       </div>
-        <div class="card-links"><a href="universalpaperclips.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/Paperclips.zip" class="card-download" download>Download</a>
+          <a href="universalpaperclips.html">More</a>
+        </div>
     </div>
 
     <div class="card" data-tags="gameboy emulator gambatte k2 k classic hf sf">
@@ -382,7 +451,10 @@
         <div class="card-desc">
         Gambatte-K2 (modern, HF+SF) and Gambatte-K (legacy, SF) let you play Game Boy/Color ROMs on Kindle.
       </div>
-        <div class="card-links"><a href="gameboy.html">More</a></div>
+        <div class="card-links">
+          <a href="gameboy.html" class="card-download">Download</a>
+          <a href="gameboy.html">More</a>
+        </div>
     </div>
 
     <div class="card" data-tags="nethack game roguelike terminal coming-soon">
@@ -393,7 +465,10 @@
         <div class="card-desc">
         Classic NetHack port in progress. Track release status, setup notes, and control guidance for the Kindle build.
       </div>
-        <div class="card-links"><a href="nethack.html">More</a></div>
+        <div class="card-links">
+          <a href="nethack.html" class="card-download">Download</a>
+          <a href="nethack.html">More</a>
+        </div>
     </div>
 
     <div class="card" data-tags="tictactoe game board kual kindle">
@@ -404,7 +479,10 @@
         <div class="card-desc">
         Simple TicTacToe extension launched from KUAL. Install and play quick matches on your Kindle.
       </div>
-        <div class="card-links"><a href="tictactoe.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/progzone122/tictactoe-kindle/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="tictactoe.html">More</a>
+        </div>
     </div>
 
     <!-- NEW: Illusion game pages -->
@@ -416,7 +494,10 @@
         <div class="card-desc">
         Classic 9×9 Sudoku for Kindle. Tap a cell and use on-screen number buttons across multiple difficulties—built on Illusion for crisp e-ink play.
       </div>
-        <div class="card-links"><a href="sudoku.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/sudoku.zip" class="card-download" download>Download</a>
+          <a href="sudoku.html">More</a>
+        </div>
     </div>
 
     <div class="card" data-tags="2048 game puzzle illusion sliding">
@@ -427,7 +508,10 @@
         <div class="card-desc">
         Combine tiles to reach 2048 using arrow-button controls. Simple, addictive number gameplay tuned for e-ink.
       </div>
-        <div class="card-links"><a href="2048.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/2048.zip" class="card-download" download>Download</a>
+          <a href="2048.html">More</a>
+        </div>
     </div>
 
     <div class="card" data-tags="snake game arcade illusion classic">
@@ -438,7 +522,10 @@
         <div class="card-desc">
         Steer with on-screen arrows, eat food to grow, and avoid walls and your tail. A clean, button-controlled classic for Kindle.
       </div>
-        <div class="card-links"><a href="snake.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/snake.zip" class="card-download" download>Download</a>
+          <a href="snake.html">More</a>
+        </div>
     </div>
 
     <div class="card" data-tags="hangman game word puzzle illusion">
@@ -449,7 +536,10 @@
         <div class="card-desc">
         Guess the hidden word using an on-screen A–Z keyboard. Clear visual feedback and e-ink-friendly layout.
       </div>
-        <div class="card-links"><a href="hangman.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/hangman.zip" class="card-download" download>Download</a>
+          <a href="hangman.html">More</a>
+        </div>
     </div>
 
     <div class="card" data-tags="connect 4 connect4 game strategy illusion">
@@ -460,7 +550,10 @@
         <div class="card-desc">
         Two-player classic on a 7×6 grid. Drop checkers via numbered column buttons (1–7) and connect four to win.
       </div>
-        <div class="card-links"><a href="connect4.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/connect4.zip" class="card-download" download>Download</a>
+          <a href="connect4.html">More</a>
+        </div>
     </div>
 
     <div class="card" data-tags="tower of hanoi puzzle game math illusion">
@@ -471,7 +564,10 @@
         <div class="card-desc">
         Move disks between pegs—one at a time, never larger on smaller. A clean Illusion build that plays perfectly on e-ink.
       </div>
-        <div class="card-links"><a href="towerofhanoi.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/tower-of-hanoi 2.zip" class="card-download" download>Download</a>
+          <a href="towerofhanoi.html">More</a>
+        </div>
     </div>
 
     <div class="card" data-tags="minecraft kindle server game kindlekraft lan smp">
@@ -482,7 +578,10 @@
         <div class="card-desc">
         Host a LAN Minecraft server (1.7–1.8) directly on your Kindle. Softfloat by default; HF possible with manual Java.
       </div>
-        <div class="card-links"><a href="kindlekraft.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/polish-penguin-dev/KindleKraft/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="kindlekraft.html">More</a>
+        </div>
     </div>
 
     <div class="card" data-tags="jarlauncher java jar minecraft tool hf sf game emulator">
@@ -493,7 +592,10 @@
         <div class="card-desc">
         Launch jar files—yes, including Minecraft—on jailbroken Kindles. Built for HF devices; SF support is untested.
       </div>
-        <div class="card-links"><a href="jarlauncher.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/ThatPotatoDev/JarLauncher/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="jarlauncher.html">More</a>
+        </div>
     </div>
     </div>
 
@@ -508,7 +610,10 @@
         <div class="card-desc">
         Bluetooth audio player for music, audiobooks, and internet streams. Supports many popular formats (WAV, MP3, FLAC, OGG, and more). Both softfloat (SF) and hardfloat (HF) versions available.
       </div>
-        <div class="card-links"><a href="sox.html">More</a></div>
+        <div class="card-links">
+          <a href="https://www.mobileread.com/forums/showthread.php?t=368945" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="sox.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="video audio experimental hf gmplay sox media">
@@ -519,7 +624,10 @@
         <div class="card-desc">
         Proof-of-concept that pairs gmplay video with SoX audio on HF Kindles. Demo media not synced; use matching files for proper sync.
       </div>
-        <div class="card-links"><a href="audiovideo.html">More</a></div>
+        <div class="card-links">
+          <a href="audiovideo.html" class="card-download">Download</a>
+          <a href="audiovideo.html">More</a>
+        </div>
     </div>
     </div>
 
@@ -532,9 +640,12 @@
           <div class="card-tags"><span class="tag">Project</span></div>
         </div>
         <div class="card-desc">
-        Minimal drawing app for Kindle—tap-based modes for dots, lines, and curves (adapted for Kindle’s gesture API).
+        Minimal drawing app for Kindle—tap-based modes for dots, lines, and curves (adapted for Kindle's gesture API).
       </div>
-        <div class="card-links"><a href="kreate.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/foskya/kreate" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="kreate.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="kpaint gameboy rom kindle gambatte">
@@ -545,7 +656,10 @@
         <div class="card-desc">
         Game Boy drawing app (ROM) optimized for Kindle display; run the ROM via Gambatte-K2 to draw with the Game Boy 4-color palette tuned for e-ink.
       </div>
-        <div class="card-links"><a href="kpaint.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/crizmo/KPaint/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="kpaint.html">More</a>
+        </div>
     </div>
     </div>
 
@@ -560,7 +674,10 @@
         <div class="card-desc">
         Block Amazon tracking, Kindle Store, and UI ads via KUAL extension that modifies /etc/hosts to disable unwanted services.
       </div>
-        <div class="card-links"><a href="blockamazon.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/mitchellurgero/kindle-kual-blockamazon/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="blockamazon.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="clear cache ads kindle ui cleanup tool">
@@ -571,7 +688,10 @@
         <div class="card-desc">
         Remove cache ads from your Kindle UI with this simple script that cleans thumbnails and ad remnants.
       </div>
-        <div class="card-links"><a href="clearadcache.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/remove_cache.zip" class="card-download" download>Download</a>
+          <a href="clearadcache.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="fullscreen browser web tool reader">
@@ -582,7 +702,10 @@
         <div class="card-desc">
         Distraction-free, true-fullscreen browser for firmware 5.16.4+. Perfect for reading long articles or running simple web apps.
       </div>
-        <div class="card-links"><a href="fullscreenweb.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/mitchellurgero/kindle-shortcut-browser/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="fullscreenweb.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="text editor tool hf gui cli lua">
@@ -593,7 +716,10 @@
         <div class="card-desc">
         Desktop-grade editor for HF Kindles: Lua-scriptable, multi-buffer, split view, with both GUI and terminal interfaces.
       </div>
-        <div class="card-links"><a href="textadept.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/textadept.zip" class="card-download" download>Download</a>
+          <a href="textadept.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="kanki flashcards spaced repetition tool">
@@ -604,7 +730,10 @@
         <div class="card-desc">
         Spaced-repetition flashcard app for Kindle. Study any language or subject offline with customizable decks.
       </div>
-        <div class="card-links"><a href="kanki.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/crizmo/KAnki/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="kanki.html">More</a>
+        </div>
     </div>
 
       <!-- NEW: Ubens recommendation (minimal insertion, same styling as other cards) -->
@@ -627,7 +756,10 @@
         <div class="card-desc">
         Analyze storage usage, find duplicates, and organize your Kindle library with this KUAL extension.
       </div>
-        <div class="card-links"><a href="storagetool.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/jkpth/StorageTool" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="storagetool.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="check ota status script tool updates jailbreak">
@@ -638,7 +770,10 @@
         <div class="card-desc">
         One-tap scriptlet that shows whether OTA updates are blocked—keep your jailbreak safe at a glance.
       </div>
-        <div class="card-links"><a href="ota.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/neura-neura/Check-OTA-status/releases" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="ota.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="koreader epub links library covers tool">
@@ -649,7 +784,10 @@
         <div class="card-desc">
         Create links in your Kindle library to open EPUBs in KOReader with cover images displaying just like Kindle books.
       </div>
-        <div class="card-links"><a href="koreader-epub-links.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/mriscott/KindleKOreaderEpubLinks/blob/main/createEpubLinks.sh" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="koreader-epub-links.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="alpine linux toolkit chromebook experiment">
@@ -660,7 +798,10 @@
         <div class="card-desc">
         Run Alpine Linux on Kindle, launch a minimal Chromium build, and explore file management—mostly for experimental fun.
       </div>
-        <div class="card-links"><a href="alpine.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/schuhumi/alpine_kindle" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="alpine.html">More</a>
+        </div>
     </div>
     </div>
 
@@ -675,7 +816,10 @@
         <div class="card-desc">
         SSH into your Kindle over USB or Wi-Fi with the streamlined hardfloat-only usbnetlite package.
       </div>
-        <div class="card-links"><a href="usbnetlite.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/notmarek/kindle-usbnetlite" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="usbnetlite.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="illusion framework dev html css js mesquite">
@@ -686,7 +830,10 @@
         <div class="card-desc">
         Build Kindle apps with HTML, CSS, and JavaScript (Mesquite web-app engine). Backbone for tools like KAnki and IllusionChess.
       </div>
-        <div class="card-links"><a href="llusion.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/polish-penguin-dev/Illusion" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="llusion.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="screencontrol remote dev tool kindle browser debug">
@@ -697,7 +844,10 @@
         <div class="card-desc">
         View and control your Kindle screen from a browser, automate taps, and debug layouts over your local network.
       </div>
-        <div class="card-links"><a href="screencontrol.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/screenControl.tar.gz" class="card-download" download>Download</a>
+          <a href="screencontrol.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="telnet server cli remote dev tool">
@@ -708,7 +858,10 @@
         <div class="card-desc">
         Lightweight Telnet server for quick remote CLI access—handy legacy alternative to SSH.
       </div>
-        <div class="card-links"><a href="telnet.html">More</a></div>
+        <div class="card-links">
+          <a href="telnet.html" class="card-download">Download</a>
+          <a href="telnet.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="nano text editor terminal dev hf kterm ssh">
@@ -719,7 +872,10 @@
         <div class="card-desc">
         Lightweight terminal editor for HF Kindles—run in KTerm or over SSH; optional syntax highlighting via <code>nanorc</code>.
       </div>
-        <div class="card-links"><a href="nano.html">More</a></div>
+        <div class="card-links">
+          <a href="downloads/nano.zip" class="card-download" download>Download</a>
+          <a href="nano.html">More</a>
+        </div>
     </div>
 
       <div class="card" data-tags="kpm kindle package manager dev mods app tool">
@@ -730,7 +886,10 @@
         <div class="card-desc">
         On-device package manager. Browse, install, update, and manage Kindle mods without manual downloads.
       </div>
-        <div class="card-links"><a href="kpm.html">More</a></div>
+        <div class="card-links">
+          <a href="https://github.com/gingrspacecadet/kpm" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="kpm.html">More</a>
+        </div>
     </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -599,7 +599,9 @@ h1 {
 .card-links {
   margin-top: auto;
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
 }
 
 .card-links a {
@@ -636,6 +638,54 @@ h1 {
 .card-links a:hover::after,
 .card-links a:focus-visible::after {
   transform: translateX(4px);
+}
+
+.card-download {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 18px;
+  border-radius: 8px;
+  background: var(--primary);
+  border: 1px solid var(--primary);
+  color: var(--bg-base);
+  font-size: 0.88em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: none;
+  box-shadow: 0 2px 8px var(--shadow-color);
+  transition: all 0.2s ease;
+  text-decoration: none;
+}
+
+.card-download::before {
+  content: "↓";
+  font-size: 1.1em;
+  transition: transform 0.2s ease;
+}
+
+.card-download:hover,
+.card-download:focus-visible {
+  background: var(--link-hover);
+  border-color: var(--link-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px var(--shadow-color);
+  text-shadow: none;
+}
+
+.card-download:hover::before,
+.card-download:focus-visible::before {
+  transform: translateY(2px);
+}
+
+.card-download.disabled {
+  background: var(--muted);
+  border-color: var(--muted);
+  color: var(--bg-base);
+  opacity: 0.6;
+  cursor: not-allowed;
+  pointer-events: none;
 }
 
 a {


### PR DESCRIPTION
- Updated Critical Updates banner to have 2 parts:
  * Part 1: DO NOT UPDATE! Amazon has released Firmware 5.18.6 which breaks adbreak!
  * Part 2: kindlemodshelf needs your help! with link to contribute page
- Added download buttons to all 53 tool/game cards on the left side
- Download buttons use proper CSS variables for full light/dark mode compatibility
- External links open in new tabs with proper security attributes
- Local files have download attribute for direct downloads
- Guide cards remain download-free (correct behavior)
- Responsive layout maintained with space-between flex layout