### PR TITLE
Build HTML editor interface

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -2722,12 +2722,7 @@ function checkAndUpdateAPKGSupport() {
     console.info('- JSZip library:', typeof JSZip !== 'undefined' ? '✓' : '✗');
     console.info('- sql.js library:', typeof initSqlJs !== 'undefined' ? '✓' : '✗');
     console.info('- WebAssembly:', typeof WebAssembly !== 'undefined' ? '✓' : '✗');
-
-    // Update file input to only accept .js files
-    const fileInput = $('#fileInput');
-    if (fileInput) {
-      fileInput.setAttribute('accept', '.js');
-    }
+    console.info('Note: .apkg files will still appear in file picker, but will show an error if selected');
   } else {
     console.info('✓ APKG import is supported - you can import Anki decks!');
   }


### PR DESCRIPTION
The file input was being restricted to only .js files when APKG support libraries weren't immediately available at page load. This prevented users from selecting .apkg files even when the libraries were actually loaded.

Changed checkAndUpdateAPKGSupport() to no longer modify the accept attribute, allowing .apkg files to always appear in the file picker. Runtime validation when importing will still warn users if their browser lacks required features.

Fixes: Unable to select .apkg files in import dialog