### PR TITLE
Fix light/dark mode and link formatting

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -2728,8 +2728,8 @@ function checkAndUpdateAPKGSupport() {
 // Ensure theme toggle button works (fallback if theme-toggle.js fails)
 (function initThemeToggleFallback() {
   const themeToggleBtn = $('.theme-toggle');
-  if (themeToggleBtn && !themeToggleBtn.hasAttribute('data-initialized')) {
-    themeToggleBtn.setAttribute('data-initialized', 'true');
+  if (themeToggleBtn && !themeToggleBtn.hasAttribute('data-theme-initialized')) {
+    themeToggleBtn.setAttribute('data-theme-initialized', 'true');
 
     // Initialize theme from localStorage
     const savedTheme = localStorage.getItem('theme');

--- a/jailbreaking.html
+++ b/jailbreaking.html
@@ -92,82 +92,175 @@
     </div>
     
     <h2 class="section-title">Step-by-Step Kindle Jailbreak Instructions (2025)</h2>
+
     <div class="card card-desc">
-      <h3>HOW TO JAILBREAK</h3>
-      <p>First check your firmware version:</p>
+      <h3>Check Your Firmware Version</h3>
+      <p>Before jailbreaking, you need to know your Kindle's firmware version:</p>
       <ol>
         <li>Turn on your Kindle</li>
         <li>Click the 3 dots on the right top hand side</li>
-        <li>Click Settings</li>
-        <li>Click Device Options</li>
-        <li>Device Info</li>
+        <li>Click <b>Settings</b></li>
+        <li>Click <b>Device Options</b></li>
+        <li>Select <b>Device Info</b></li>
         <li>Check your firmware version</li>
       </ol>
-      <p>Jailbreak your Kindle using the appropriate guide:</p>
+    </div>
+
+    <div class="card card-desc">
+      <h3>Choose Your Jailbreak Method</h3>
+      <p>Select the appropriate jailbreak for your firmware version:</p>
       <ul>
-        <li><b>Firmware 5.16.2.1.1 or earlier:</b> Use Legacy jailbreaks<br><a href="https://kindlemodding.org/jailbreaking/Legacy/index.html" target="_blank" rel="noopener">https://kindlemodding.org/jailbreaking/Legacy/index.html</a></li>
-        <li><b>Firmware 5.16.3 to 5.18.0:</b> Use WinterBreak<br><a href="https://kindlemodding.org/jailbreaking/WinterBreak/" target="_blank" rel="noopener">https://kindlemodding.org/jailbreaking/WinterBreak/</a></li>
-        <li><b>Firmware 5.18.1 to 5.18.5:</b> Use AdBreak<br><a href="https://kindlemodding.org/jailbreaking/AdBreak/" target="_blank" rel="noopener">https://kindlemodding.org/jailbreaking/AdBreak/</a></li>
-        <li><b>Firmware 5.18.6 and later:</b> Currently has no jailbreak</li>
+        <li><b>Firmware 5.16.2.1.1 or earlier:</b> Use Legacy jailbreaks
+          <br>→ <a href="https://kindlemodding.org/jailbreaking/Legacy/index.html" target="_blank" rel="noopener">Legacy Jailbreak Guide</a>
+        </li>
+        <li><b>Firmware 5.16.3 to 5.18.0:</b> Use WinterBreak
+          <br>→ <a href="https://kindlemodding.org/jailbreaking/WinterBreak/" target="_blank" rel="noopener">WinterBreak Jailbreak Guide</a>
+        </li>
+        <li><b>Firmware 5.18.1 to 5.18.5:</b> Use AdBreak
+          <br>→ <a href="https://kindlemodding.org/jailbreaking/AdBreak/" target="_blank" rel="noopener">AdBreak Jailbreak Guide</a>
+        </li>
+        <li><b>Firmware 5.18.6 and later:</b> Currently has no jailbreak available</li>
       </ul>
-      <p><b>Note:</b> I have not included legacy jailbreak methods like KindleBreak or WatchThis or LanguageBreak. Check <a href="https://kindlemodding.org/jailbreaking/Legacy/index.html" target="_blank" rel="noopener">https://kindlemodding.org/jailbreaking/Legacy/index.html</a> for more info if you have a legacy Kindle.</p>
+      <p style="margin-top:1em;"><b>Note:</b> Legacy jailbreak methods like KindleBreak, WatchThis, and LanguageBreak are available in the <a href="https://kindlemodding.org/jailbreaking/Legacy/index.html" target="_blank" rel="noopener">Legacy Guide</a> for older Kindles.</p>
+    </div>
 
-      <h3>AFTER JAILBREAK</h3>
-      <p>Make sure you have installed Block OTA Updates, MRPI, and KUAL from the guide at <a href="https://kindlemodding.org/jailbreaking/post-jailbreak/index.html" target="_blank" rel="noopener">https://kindlemodding.org/jailbreaking/post-jailbreak/index.html</a></p>
-      <p>This should be integrated with the jailbreaking process, but it is important to make sure!</p>
-      <p>Congratulations! You have now freed yourself from the grasp of Amazon!</p>
-      <p>But now what?</p>
-      <p>Well, <a href="index.html">kindlemodshelf.me</a> is designed for you! It has basically every mod, plugin, and patch that works on Kindle. But that can be a little overwhelming, which is why I have made this guide. Here are what I consider essential when you start jailbreaking.</p>
+    <div class="card card-desc">
+      <h3>Post-Jailbreak Setup</h3>
+      <p>After successfully jailbreaking, you must install these essential components:</p>
+      <ul>
+        <li><b>Block OTA Updates</b> - Prevents Amazon from forcing firmware updates</li>
+        <li><b>MRPI</b> - Mobileread Package Installer</li>
+        <li><b>KUAL</b> - Kindle Unified Application Launcher</li>
+      </ul>
+      <p style="margin-top:1em;">→ <a href="https://kindlemodding.org/jailbreaking/post-jailbreak/index.html" target="_blank" rel="noopener">Complete Post-Jailbreak Setup Guide</a></p>
+      <p style="margin-top:1em;"><b>Important:</b> This should be integrated with the jailbreaking process, but double-check to make sure everything is installed!</p>
+      <p style="margin-top:1em;">🎉 Congratulations! You have now freed yourself from the grasp of Amazon!</p>
+    </div>
 
-      <h3>ESSENTIAL MODS</h3>
-      <p>Start with installing KindleForge:</p>
-      <p><a href="kindleforge.html">kindleforge</a></p>
-      <p>KindleForge is an app store for Kindles that allows you to download and install mods directly on your device, without needing to copy files manually.</p>
-      <p>Then open KindleForge and install whatever you want. However, to start off with, I would recommend installing:</p>
+    <h2 class="section-title">Essential Mods to Get Started</h2>
+
+    <div class="card card-desc">
+      <h3>1. Install KindleForge (App Store)</h3>
+      <p>→ <a href="kindleforge.html">KindleForge Installation Guide</a></p>
+      <p>KindleForge is an app store for Kindles that allows you to download and install mods directly on your device, without needing to copy files manually. Start here for the easiest modding experience!</p>
+    </div>
+
+    <div class="card card-desc">
+      <h3>2. Essential Apps from KindleForge</h3>
+      <p>Once KindleForge is installed, download these must-have apps:</p>
       <ol>
-        <li><b>KOReader</b><br><a href="koreader.html">koreader</a><br>KOReader is a free, open-source eBook reader app designed for e-ink devices. See the official guide on how to use it here: <a href="https://koreader.rocks/" target="_blank" rel="noopener">https://koreader.rocks/</a></li>
-        <li><b>KTerm</b> (<a href="kterm.html">kterm</a>)<br>KTerm is the essential terminal emulator for jailbroken Kindle e-readers. Even if you have no idea how to use it, it is a dependency for a lot of other apps.</li>
-        <li><b>UpdateBlock Status</b><br>This will give you the peace of mind to make sure that Amazon cannot force remove your Kindle's updates. If it is not blocked, go back to <a href="https://kindlemodding.org/jailbreaking/post-jailbreak/index.html" target="_blank" rel="noopener">https://kindlemodding.org/jailbreaking/post-jailbreak/index.html</a></li>
-        <li><b>KUAL (otherwise known as PEKI)</b><br><a href="peki.html">peki</a><br>PEKI installs and launches KUAL without MRPI and delivers a polished icon.</li>
-        <li><b>Toggle ADs</b><br><a href="disableads.html">disableads</a><br>Allows you to remove ads from your Kindle lock screen for free. Normally, Amazon charges you $20.</li>
+        <li>
+          <b>KOReader</b> - Advanced eBook reader
+          <br>→ <a href="koreader.html">KOReader Guide</a> | <a href="https://koreader.rocks/" target="_blank" rel="noopener">Official Documentation</a>
+          <br><span style="color:var(--muted);">Free, open-source eBook reader supporting EPUB, PDF, CBZ, and more formats with advanced customization</span>
+        </li>
+        <li>
+          <b>KTerm</b> - Terminal emulator
+          <br>→ <a href="kterm.html">KTerm Guide</a>
+          <br><span style="color:var(--muted);">Essential terminal emulator and dependency for many other apps</span>
+        </li>
+        <li>
+          <b>UpdateBlock Status</b> - Verify OTA protection
+          <br><span style="color:var(--muted);">Confirms Amazon cannot force firmware updates on your device</span>
+        </li>
+        <li>
+          <b>KUAL/PEKI</b> - App launcher
+          <br>→ <a href="peki.html">PEKI Installation Guide</a>
+          <br><span style="color:var(--muted);">Installs and launches KUAL without MRPI with a polished icon</span>
+        </li>
+        <li>
+          <b>Toggle Ads</b> - Remove lock screen ads
+          <br>→ <a href="disableads.html">Disable Ads Guide</a>
+          <br><span style="color:var(--muted);">Remove ads from your Kindle lock screen for free (normally $20)</span>
+        </li>
       </ol>
-      <p>KindleForge is really excellent and I would recommend you check out the other mods it offers, but a lot of them are not on my essential list, like KindleCraft which turns your Kindle into a Minecraft server.</p>
+    </div>
 
-      <h3>OPENING APPS</h3>
-      <p>There are two main ways to open apps: as a scriptlet which shows up as a book in your library, or through KUAL.</p>
-      <p>Run scriptlets by tapping on them in your library.</p>
-      <p>Run apps in KUAL by opening the KUAL scriptlet and then clicking on the app you want to run.</p>
-      <p>Manual installation is not that hard. Just follow the step by step guides I am providing.</p>
+    <div class="card card-desc">
+      <h3>How to Open Apps</h3>
+      <p>There are two main ways to launch apps on your jailbroken Kindle:</p>
+      <ul>
+        <li><b>Scriptlets:</b> Show up as books in your library - just tap to run</li>
+        <li><b>KUAL:</b> Open the KUAL scriptlet, then select the app you want to run</li>
+      </ul>
+      <p style="margin-top:1em;">Manual installation is straightforward - just follow the step-by-step guides provided for each mod.</p>
+    </div>
 
-      <h3>BLOCKING AMAZON</h3>
-      <p><a href="blockamazon.html">blockamazon</a></p>
-      <p>Amazon tracks literally everything you do even after you are jailbroken. Amazon tracks where you click with millimeter precision, what books you open, how long you are reading, and literally everything you can imagine to make money selling your preferences and serve you ads on Amazon and on your Kindle. This script blocks Amazon tracking, Kindle Store, and UI ads on your Kindle.</p>
-      <p>If you want to see Amazon tracking in real time, open KTerm and type in:</p>
+    <h2 class="section-title">Privacy & Customization</h2>
+
+    <div class="card card-desc">
+      <h3>Block Amazon Tracking</h3>
+      <p>→ <a href="blockamazon.html">Block Amazon Tracking Script</a></p>
+      <p>Amazon tracks literally everything you do, even after jailbreaking: where you click with millimeter precision, what books you open, how long you read, and more. This data is used to serve you ads and sold to advertisers.</p>
+      <p><b>This script blocks:</b></p>
+      <ul>
+        <li>Amazon tracking and analytics</li>
+        <li>Kindle Store access</li>
+        <li>UI advertisements</li>
+      </ul>
+      <p style="margin-top:1em;"><b>See tracking in real-time:</b> Open KTerm and type:</p>
       <p><code>tail -F /var/log/messages</code></p>
-      <p>After blocking Amazon you will still see cached ads on the UI. CLEAR ADS CACHE script removes them.</p>
-      <p><a href="clearadcache.html">clearadcache</a></p>
-      <p>You will still see popular reads ads, but these require editing system files which could brick your Kindle. However, if you want to remove the images from the popular books, the commands are available at <a href="index.html">kindlemodshelf.me</a> under OTHER COOL STUFF section.</p>
+    </div>
 
-      <h3>KOREADER MODDING</h3>
-      <p>KOReader by default is pretty bland. It does not look nice, and it does not have some features that the original Kindle does.</p>
-      <p>One of people's favorite things to do with KOReader is add custom screensavers. See over 1000+ images at <a href="images.html">images</a> and how to install here: <a href="customscreensavers.html">customscreensavers</a></p>
-      <p>KOReader also allows the community to create plugins and user patches!</p>
-      <p>The first plugin you should install is Project Title!</p>
-      <p>Project Title adds a TON of UI features that beautify KOReader! It can be a little bit difficult to install sometimes but just follow the guide carefully.</p>
-      <p><a href="projecttitle.html">projecttitle</a></p>
-      <p>There are so many other plugins and patches that I cannot exactly list them all here, nor is that the point of this guide. You can go and check out which ones you want to install for yourself at:</p>
-      <p><a href="plugins.html">plugins</a></p>
-      <p><a href="patches.html">patches</a></p>
-      <p>One of my favorite user patches is Page Header which makes your Kindle look like an actual book.</p>
-      <p><a href="pageheader.html">pageheader</a></p>
+    <div class="card card-desc">
+      <h3>Clear Cached Ads</h3>
+      <p>→ <a href="clearadcache.html">Clear Ad Cache Script</a></p>
+      <p>After blocking Amazon, you may still see cached ads in the UI. This script removes them completely.</p>
+      <p style="margin-top:1em;"><b>Note:</b> Popular reads ads require editing system files which could brick your Kindle. If you want to remove those images, commands are available at <a href="index.html">kindlemodshelf.me</a> under the "Other Cool Stuff" section.</p>
+    </div>
 
-      <h3>ADDITIONAL FEATURES</h3>
-      <p>There are a ton of games you can play on your Kindle. Play Kindle Wordle or play games inside of a Game Boy emulator. See the games section on <a href="index.html">kindlemodshelf.me</a></p>
-      <p>A really great use of your Kindle is as a flashcard app. KAnki is based on the hugely popular Anki which focuses on spaced repetition to memorize flashcards.</p>
-      <p><a href="kanki.html">kanki</a></p>
-      <p>It is available in the KindleForge app store.</p>
-      <p>To easily create and manage your KAnki decks on your Kindle, I made <a href="editor.html">editor</a></p>
-      <p>If you love KAnki, also check out Ubens at <a href="https://ubens.vercel.app/" target="_blank" rel="noopener">https://ubens.vercel.app/</a> which was made by the same guy and allows you to have an Anki-like experience that is easy to sync with your Kindle!</p>
+    <h2 class="section-title">KOReader Customization</h2>
+
+    <div class="card card-desc">
+      <h3>Custom Screensavers</h3>
+      <p>KOReader by default is pretty bland, but you can customize it extensively!</p>
+      <p>One of the most popular customizations is adding custom screensavers:</p>
+      <ul>
+        <li>→ <a href="images.html">Browse 1000+ Screensaver Images</a></li>
+        <li>→ <a href="customscreensavers.html">Installation Guide</a></li>
+      </ul>
+    </div>
+
+    <div class="card card-desc">
+      <h3>KOReader Plugins & Patches</h3>
+      <p>The KOReader community has created numerous plugins and user patches to enhance functionality:</p>
+
+      <p style="margin-top:1em;"><b>Start with Project Title:</b></p>
+      <p>→ <a href="projecttitle.html">Project Title Installation Guide</a></p>
+      <p>Project Title adds a ton of UI features that beautify KOReader! Installation can be tricky, so follow the guide carefully.</p>
+
+      <p style="margin-top:1.5em;"><b>Explore more customizations:</b></p>
+      <ul>
+        <li>→ <a href="plugins.html">All KOReader Plugins</a></li>
+        <li>→ <a href="patches.html">All User Patches</a></li>
+        <li>→ <a href="pageheader.html">Page Header Patch</a> - Makes your Kindle look like an actual book</li>
+      </ul>
+    </div>
+
+    <h2 class="section-title">Additional Features</h2>
+
+    <div class="card card-desc">
+      <h3>Games & Entertainment</h3>
+      <p>Your jailbroken Kindle can run various games:</p>
+      <ul>
+        <li>Kindle Wordle</li>
+        <li>Game Boy emulator</li>
+        <li>Classic games and more</li>
+      </ul>
+      <p style="margin-top:1em;">→ See all available games in the games section on <a href="index.html">kindlemodshelf.me</a></p>
+    </div>
+
+    <div class="card card-desc">
+      <h3>Flashcards with KAnki</h3>
+      <p>→ <a href="kanki.html">KAnki Installation Guide</a></p>
+      <p>Turn your Kindle into a powerful flashcard app! KAnki is based on the hugely popular Anki, using spaced repetition to help you memorize effectively.</p>
+      <p><b>Available in the KindleForge app store.</b></p>
+
+      <p style="margin-top:1.5em;"><b>Deck Management Tools:</b></p>
+      <ul>
+        <li>→ <a href="editor.html">KAnki Deck Editor</a> - Create and manage decks easily</li>
+        <li>→ <a href="https://ubens.vercel.app/" target="_blank" rel="noopener">Ubens</a> - Anki-like experience with easy Kindle syncing (by the same developer)</li>
+      </ul>
     </div>
 
     <h2 class="section-title">Kindle Jailbreak Community & Support</h2>

--- a/theme-toggle.js
+++ b/theme-toggle.js
@@ -46,6 +46,8 @@
     const existingButton = document.querySelector('.theme-toggle');
 
     if (existingButton) {
+      // Mark as initialized to prevent duplicate handlers
+      existingButton.setAttribute('data-theme-initialized', 'true');
       // Attach click handler to existing button
       existingButton.addEventListener('click', toggleTheme);
       return;


### PR DESCRIPTION
- Fixed theme toggle in editor.html by coordinating theme-toggle.js with fallback handler
- Added data-theme-initialized attribute to prevent duplicate event listeners
- Reorganized jailbreaking.html into cleaner, focused cards for better readability
- Improved link formatting with descriptive text instead of bare URLs
- Added visual hierarchy with arrows and muted text for descriptions
- Separated massive single card into 11 focused cards organized by topic