### PR TITLE
Fix editor.html theme toggle by removing duplicate handler

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -2724,38 +2724,6 @@ function checkAndUpdateAPKGSupport() {
     console.info('✓ APKG import is supported - you can import Anki decks!');
   }
 }
-
-// Ensure theme toggle button works (fallback if theme-toggle.js fails)
-(function initThemeToggleFallback() {
-  const themeToggleBtn = $('.theme-toggle');
-  if (themeToggleBtn && !themeToggleBtn.hasAttribute('data-theme-initialized')) {
-    themeToggleBtn.setAttribute('data-theme-initialized', 'true');
-
-    // Initialize theme from localStorage
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme === 'light') {
-      document.documentElement.setAttribute('data-theme', 'light');
-    }
-
-    // Add click handler as fallback
-    const toggleThemeHandler = () => {
-      const root = document.documentElement;
-      const currentTheme = root.getAttribute('data-theme');
-      const newTheme = currentTheme === 'light' ? 'dark' : 'light';
-
-      if (newTheme === 'light') {
-        root.setAttribute('data-theme', 'light');
-      } else {
-        root.removeAttribute('data-theme');
-      }
-
-      localStorage.setItem('theme', newTheme);
-      showToast(`Switched to ${newTheme} mode`);
-    };
-
-    themeToggleBtn.addEventListener('click', toggleThemeHandler);
-  }
-})();
 </script>
 
 </body>


### PR DESCRIPTION
Removed the fallback theme toggle implementation that was causing
conflicts with theme-toggle.js. The page had two event handlers
attached to the theme button which would execute sequentially and
cancel each other out, preventing theme switching from working.

The theme-toggle.js script already provides full functionality, so
the fallback code was redundant and causing the issue.

Fixes white mode conversion issue.