### PR TITLE
Improve images.html layout and styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -1250,17 +1250,17 @@ pre {
 
 .gallery-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 18px;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 12px;
   padding: 6px;
 }
 
 .img-thumb-wrap {
   position: relative;
   width: 100%;
-  height: 240px;
+  aspect-ratio: 3 / 4;
   overflow: hidden;
-  border-radius: 16px;
+  border-radius: 12px;
   cursor: pointer;
   box-shadow: 0 2px 8px var(--shadow-color);
   transition: transform 0.24s ease, box-shadow 0.28s ease, border-color 0.28s ease, filter 0.28s ease;
@@ -1278,8 +1278,8 @@ pre {
 .img-thumb {
   width: 100%;
   height: 100%;
-  border-radius: 14px;
-  object-fit: cover;
+  border-radius: 10px;
+  object-fit: contain;
   object-position: center;
   transition: opacity 0.24s ease, transform 0.24s ease;
   opacity: 0.3;


### PR DESCRIPTION
- Reduce grid cell size from 220px to 140px to show more images
- Replace fixed height with aspect-ratio 3/4 for flexible layouts
- Change object-fit from cover to contain to prevent image cropping
- Adjust gaps and border radius for tighter, cleaner layout