### PR TITLE
Redesign image gallery with optimized layout for Kindle screens

### DIFF
--- a/images.html
+++ b/images.html
@@ -61,9 +61,9 @@
     <script>
     const INITIAL_AUTHORS = 10;
     const LOAD_MORE_AUTHORS = 6;
-    const PREVIEW_IMAGE_COUNT = 8;
-    const THUMBNAIL_WIDTH = 520;
-    const THUMBNAIL_HEIGHT = 520;
+    const PREVIEW_IMAGE_COUNT = 6;
+    const THUMBNAIL_WIDTH = 400;
+    const THUMBNAIL_HEIGHT = 533;
     const THUMBNAIL_QUALITY = 0.82;
     const PLACEHOLDER_SRC = 'data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=';
     const SECTION_UNLOAD_OFFSET = 1400;
@@ -353,8 +353,16 @@
       const images = allData[meta.author] || [];
       if (!images.length) return;
 
-      // Show all images from the start
-      images.forEach(filename => addImageToGrid(meta.grid, meta.author, filename));
+      // Show only preview images initially
+      const previewImages = images.slice(0, PREVIEW_IMAGE_COUNT);
+      previewImages.forEach(filename => addImageToGrid(meta.grid, meta.author, filename));
+
+      // Add "Show More" button if there are more images
+      if (images.length > PREVIEW_IMAGE_COUNT) {
+        const btn = createLoadMoreButton(meta, images);
+        meta.controls.appendChild(btn);
+        meta.loadMoreBtn = btn;
+      }
 
       meta.rendered = true;
     }

--- a/style.css
+++ b/style.css
@@ -1460,8 +1460,8 @@ section[data-author] .section-title::after {
 
 .gallery-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 14px;
   padding: 0;
 }
 
@@ -1470,14 +1470,14 @@ section[data-author] .section-title::after {
   display: block;
   width: 100%;
   overflow: hidden;
-  border-radius: 10px;
+  border-radius: 8px;
   cursor: pointer;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
   transition: transform 0.2s ease,
               box-shadow 0.2s ease;
   border: 1px solid var(--gallery-card-border);
   background: var(--img-thumb-bg);
-  aspect-ratio: 1;
+  aspect-ratio: 3 / 4;
 }
 
 .img-thumb-wrap:hover {
@@ -1901,8 +1901,8 @@ section[data-author] .section-title::after {
 /* Responsive adjustments for gallery */
 @media (max-width: 1200px) {
   .gallery-grid {
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-    gap: 14px;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 12px;
   }
 
   section[data-author] .section-title {
@@ -1912,7 +1912,7 @@ section[data-author] .section-title::after {
 
 @media (max-width: 992px) {
   .gallery-grid {
-    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
     gap: 12px;
   }
 
@@ -1923,8 +1923,8 @@ section[data-author] .section-title::after {
 
 @media (max-width: 768px) {
   .gallery-grid {
-    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-    gap: 12px;
+    grid-template-columns: repeat(auto-fill, minmax(105px, 1fr));
+    gap: 10px;
   }
 
   .gallery-card {
@@ -1943,7 +1943,7 @@ section[data-author] .section-title::after {
 
 @media (max-width: 640px) {
   .gallery-grid {
-    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(95px, 1fr));
     gap: 10px;
   }
 
@@ -1954,8 +1954,8 @@ section[data-author] .section-title::after {
 
 @media (max-width: 480px) {
   .gallery-grid {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 10px;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
   }
 
   .gallery-card {


### PR DESCRIPTION
- Changed image aspect ratio from 1:1 to 3:4 to properly display rectangular Kindle images
- Reduced image size from 200px to 130px base width for better density and professional look
- Show only 6 preview images per author initially with "Show More" button
- Updated thumbnail generation to 400x533 for optimal 3:4 aspect ratio
- Improved responsive breakpoints for all screen sizes
- Mobile view now displays 3 columns instead of 2 for better utilization
- Tightened grid gaps and reduced border-radius for cleaner appearance