### PR TITLE
Refactor UI: Minimal icons and blue highlights

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,12 @@
       <div class="search-block">
         <label for="search-bar" class="search-label">Search the catalog</label>
         <div class="search-input-shell">
-          <span class="search-icon" aria-hidden="true">🔍</span>
+          <span class="search-icon" aria-hidden="true">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="11" cy="11" r="8"></circle>
+              <path d="m21 21-4.35-4.35"></path>
+            </svg>
+          </span>
           <input type="text" id="search-bar" placeholder="Find tools, plugins, games…" autocomplete="off">
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -68,9 +68,9 @@
   --filter-chip-border: #3a3a3a;
   --filter-chip-text: #c8c8c8;
   --filter-chip-hover-border: #4a4a4a;
-  --filter-chip-active-bg: #3a2a2a;
-  --filter-chip-active-border: #8a4a4a;
-  --filter-chip-active-text: #ffcccc;
+  --filter-chip-active-bg: #2a3a4a;
+  --filter-chip-active-border: #5b9dd9;
+  --filter-chip-active-text: #b3d9ff;
   --gallery-card-bg: #222222;
   --gallery-card-border: #3a3a3a;
   --morris-bg: #242424;
@@ -229,9 +229,9 @@
   --filter-chip-border: #dddddd;
   --filter-chip-text: #555555;
   --filter-chip-hover-border: #cccccc;
-  --filter-chip-active-bg: #fff0f0;
-  --filter-chip-active-border: #dd8888;
-  --filter-chip-active-text: #883333;
+  --filter-chip-active-bg: #e6f2ff;
+  --filter-chip-active-border: #5b9dd9;
+  --filter-chip-active-text: #2563ab;
   --gallery-card-bg: #f8f8f8;
   --gallery-card-border: #dddddd;
   --morris-bg: #f8f8f8;
@@ -1068,11 +1068,7 @@ pre code {
   box-shadow: 0 2px 4px var(--shadow-color);
 }
 
-.back-home-btn::before {
-  content: "←";
-  font-size: 1.2em;
-  font-weight: 600;
-}
+/* Back arrow removed per user request */
 
 @media (max-width: 700px) {
   .back-home-btn {
@@ -1121,6 +1117,9 @@ pre code {
   left: 14px;
   color: var(--search-icon);
   pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #search-bar {
@@ -1906,26 +1905,26 @@ pre code {
   display: flex;
 }
 
-/* Dark mode: vibrant gold star with glow */
+/* Dark mode: white circle */
 :root .theme-icon.sun svg {
-  color: #ffd700;
-  filter: drop-shadow(0 0 3px rgba(255, 215, 0, 0.6)) drop-shadow(0 0 6px rgba(255, 215, 0, 0.3));
+  color: #ffffff;
+  filter: none;
 }
 
 :root .theme-toggle:hover .theme-icon.sun svg {
-  color: #ffed4e;
-  filter: drop-shadow(0 0 4px rgba(255, 237, 78, 0.8)) drop-shadow(0 0 8px rgba(255, 215, 0, 0.4));
+  color: #ffffff;
+  filter: none;
 }
 
-/* Light mode: rich blue moon with glow */
+/* Light mode: black circle */
 :root[data-theme="light"] .theme-icon.moon svg {
-  color: #4a8fd9;
-  filter: drop-shadow(0 0 3px rgba(74, 143, 217, 0.5)) drop-shadow(0 0 6px rgba(91, 157, 217, 0.25));
+  color: #000000;
+  filter: none;
 }
 
 :root[data-theme="light"] .theme-toggle:hover .theme-icon.moon svg {
-  color: #5b9dd9;
-  filter: drop-shadow(0 0 4px rgba(91, 157, 217, 0.7)) drop-shadow(0 0 8px rgba(74, 143, 217, 0.35));
+  color: #000000;
+  filter: none;
 }
 
 @media (max-width: 700px) {

--- a/theme-toggle.js
+++ b/theme-toggle.js
@@ -59,17 +59,17 @@
     button.setAttribute('aria-label', 'Toggle theme');
     button.setAttribute('title', 'Toggle theme');
 
-    // Create star icon SVG (shows in dark mode - to switch to light)
+    // Create circle icon (shows in dark mode - white circle)
     const starIcon = document.createElement('span');
     starIcon.className = 'theme-icon sun';
     starIcon.setAttribute('aria-hidden', 'true');
-    starIcon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon></svg>';
+    starIcon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="8"></circle></svg>';
 
-    // Create moon icon SVG (shows in light mode - to switch to dark)
+    // Create circle icon (shows in light mode - black circle)
     const moonIcon = document.createElement('span');
     moonIcon.className = 'theme-icon moon';
     moonIcon.setAttribute('aria-hidden', 'true');
-    moonIcon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>';
+    moonIcon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="8"></circle></svg>';
 
     button.appendChild(starIcon);
     button.appendChild(moonIcon);


### PR DESCRIPTION
- Remove back arrow from back-home button for cleaner look
- Replace colored star/moon theme toggle with minimal black/white circle icons
- Change category filter highlights from red to blue across both themes
- Replace search emoji with clean SVG icon
- Theme toggle remains fixed on bottom-left corner

All changes maintain existing HTML structure and class names for compatibility.