### PR TITLE
Fix dark mode toggle: add moon/sun icons and ensure fixed position

### DIFF
--- a/style.css
+++ b/style.css
@@ -1837,7 +1837,6 @@ pre code {
   padding: 0;
   box-shadow: 0 2px 4px var(--shadow-color), 0 4px 8px rgba(0, 0, 0, 0.08);
   overflow: hidden;
-  position: relative;
 }
 
 .theme-toggle::before {
@@ -1905,10 +1904,22 @@ pre code {
   display: flex;
 }
 
-/* Dark mode: white circle */
+/* Dark mode: white sun icon */
 :root .theme-icon.sun svg {
   color: #ffffff;
   filter: none;
+}
+
+:root .theme-icon.sun svg path {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+:root .theme-icon.sun svg circle {
+  fill: currentColor;
 }
 
 :root .theme-toggle:hover .theme-icon.sun svg {
@@ -1916,10 +1927,14 @@ pre code {
   filter: none;
 }
 
-/* Light mode: black circle */
+/* Light mode: black moon icon */
 :root[data-theme="light"] .theme-icon.moon svg {
   color: #000000;
   filter: none;
+}
+
+:root[data-theme="light"] .theme-icon.moon svg path {
+  fill: currentColor;
 }
 
 :root[data-theme="light"] .theme-toggle:hover .theme-icon.moon svg {

--- a/theme-toggle.js
+++ b/theme-toggle.js
@@ -59,17 +59,17 @@
     button.setAttribute('aria-label', 'Toggle theme');
     button.setAttribute('title', 'Toggle theme');
 
-    // Create circle icon (shows in dark mode - white circle)
+    // Create sun icon (shows in dark mode - clicking switches to light mode)
     const starIcon = document.createElement('span');
     starIcon.className = 'theme-icon sun';
     starIcon.setAttribute('aria-hidden', 'true');
-    starIcon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="8"></circle></svg>';
+    starIcon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.22 4.22l1.42 1.42m12.72 12.72l1.42 1.42M2 12h2m16 0h2M4.22 19.78l1.42-1.42m12.72-12.72l1.42-1.42"/></svg>';
 
-    // Create circle icon (shows in light mode - black circle)
+    // Create moon icon (shows in light mode - clicking switches to dark mode)
     const moonIcon = document.createElement('span');
     moonIcon.className = 'theme-icon moon';
     moonIcon.setAttribute('aria-hidden', 'true');
-    moonIcon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="8"></circle></svg>';
+    moonIcon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
 
     button.appendChild(starIcon);
     button.appendChild(moonIcon);


### PR DESCRIPTION
- Replace circle icons with proper sun icon (rays + center) and crescent moon icon
- Fix position conflict: remove duplicate position:relative that prevented fixed positioning
- Add proper SVG styling for sun rays (stroke) and moon (fill)
- Toggle now properly stays in bottom-left corner while scrolling
- All CSS remains in style.css as requested