### PR TITLE
Update KOReader messages and clean up jailbreaking page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1104,7 +1104,10 @@ let activeCategory = 'all';
       if (!filterNote) return;
       let message = '';
       if (activeCategory === 'koreader') {
-        message = 'Tip: Install <a href="koreader.html">KOReader</a> first to make the most of these plugins.';
+        message = 'Tip: Install <a href="koreader.html">KOReader</a> to use these plug-ins.';
+      }
+      if (activeCategory === 'patches') {
+        message = 'Tip: Install <a href="koreader.html">KOReader</a> to use these patches.';
       }
       if (message) {
         filterNote.innerHTML = message;

--- a/jailbreaking.html
+++ b/jailbreaking.html
@@ -134,7 +134,7 @@
       </ul>
       <p style="margin-top:1em;">→ <a href="https://kindlemodding.org/jailbreaking/post-jailbreak/index.html" target="_blank" rel="noopener">Complete Post-Jailbreak Setup Guide</a></p>
       <p style="margin-top:1em;"><b>Important:</b> This should be integrated with the jailbreaking process, but double-check to make sure everything is installed!</p>
-      <p style="margin-top:1em;">🎉 Congratulations! You have now freed yourself from the grasp of Amazon!</p>
+      <p style="margin-top:1em;">Congratulations! You have now freed yourself from the grasp of Amazon!</p>
     </div>
 
     <h2 class="section-title">Essential Mods to Get Started</h2>
@@ -198,8 +198,6 @@
         <li>Kindle Store access</li>
         <li>UI advertisements</li>
       </ul>
-      <p style="margin-top:1em;"><b>See tracking in real-time:</b> Open KTerm and type:</p>
-      <p><code>tail -F /var/log/messages</code></p>
     </div>
 
     <div class="card card-desc">


### PR DESCRIPTION
- Change KOReader plugins tip to clearer message
- Add tip message for patches category
- Remove emoji from jailbreaking congratulations text
- Remove real-time tracking command section