### PR TITLE
Fix alpine.html overlap and update download links

### DIFF
--- a/alpine.html
+++ b/alpine.html
@@ -27,12 +27,12 @@
 </head>
 
 <body>
-  <div class="card card-desc legal-warning">
-    <p><strong>Use at your own risk.</strong></p>
-  </div>
-
   <div class="container">
     <a href="index.html" class="back-home-btn" aria-label="Back to Home">← Back to Home</a>
+
+    <div class="card card-desc legal-warning" style="margin-top: 0;">
+      <p><strong>Use at your own risk.</strong></p>
+    </div>
 
     <h1>ALPINE LINUX</h1>
 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,6 @@
         Drop desired <code>.sh</code> launcher scripts into <code>/mnt/us/documents</code>. Tap them on the Home screen to open apps directly—no KUAL required.
       </div>
       <div class="card-links">
-        <a href="shortcuts.html" class="card-download">Download</a>
         <a href="shortcuts.html">More</a>
       </div>
     </div>
@@ -211,7 +210,6 @@
         Curated roundup of the most useful KOReader plugins—with quick summaries, download links, and setup notes for each add-on.
       </div>
         <div class="card-links">
-          <a href="plugins.html" class="card-download">Download</a>
           <a href="plugins.html">More</a>
         </div>
     </div>
@@ -327,7 +325,6 @@
         Installation guide plus curated user patches—browser, UI, status bar, screensaver, and Project: Title extensions.
       </div>
         <div class="card-links">
-          <a href="patches.html" class="card-download">Download</a>
           <a href="patches.html">More</a>
         </div>
     </div>
@@ -401,7 +398,6 @@
         Strategy board game in two editions: softfloat (launches from KUAL) or hardfloat (runs in KTerm).
       </div>
         <div class="card-links">
-          <a href="ninemensmorris.html" class="card-download">Download</a>
           <a href="ninemensmorris.html">More</a>
         </div>
     </div>
@@ -415,7 +411,6 @@
         Play Z-Machine, Glulx, TADS, and other interactive fiction formats on Kindle with dedicated HF and SF builds.
       </div>
         <div class="card-links">
-          <a href="gargoyle.html" class="card-download">Download</a>
           <a href="gargoyle.html">More</a>
         </div>
     </div>
@@ -457,7 +452,6 @@
         Gambatte-K2 (modern, HF+SF) and Gambatte-K (legacy, SF) let you play Game Boy/Color ROMs on Kindle.
       </div>
         <div class="card-links">
-          <a href="gameboy.html" class="card-download">Download</a>
           <a href="gameboy.html">More</a>
         </div>
     </div>
@@ -616,7 +610,7 @@
         Proof-of-concept that pairs gmplay video with SoX audio on HF Kindles. Demo media not synced; use matching files for proper sync.
       </div>
         <div class="card-links">
-          <a href="audiovideo.html" class="card-download">Download</a>
+          <a href="https://drive.google.com/file/d/1633_dfciSHXBJbkhkTucIDFEsM4Z7SLX/view" class="card-download" target="_blank" rel="noopener">Download</a>
           <a href="audiovideo.html">More</a>
         </div>
     </div>
@@ -804,7 +798,7 @@
         Run Alpine Linux on Kindle, launch a minimal Chromium build, and explore file management—mostly for experimental fun.
       </div>
         <div class="card-links">
-          <a href="https://github.com/schuhumi/alpine_kindle" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="https://github.com/GreenCat-777/QuickAlpine/releases" class="card-download" target="_blank" rel="noopener">Download</a>
           <a href="alpine.html">More</a>
         </div>
     </div>
@@ -864,7 +858,6 @@
         Lightweight Telnet server for quick remote CLI access—handy legacy alternative to SSH.
       </div>
         <div class="card-links">
-          <a href="telnet.html" class="card-download">Download</a>
           <a href="telnet.html">More</a>
         </div>
     </div>


### PR DESCRIPTION
- Fix overlap between back home button and 'use at your own risk' warning in alpine.html
- Remove duplicate download links that go to same page as 'more info':
  - Home Screen Shortcuts
  - Featured KOReader Plugins
  - KOReader Patches Library
  - Nine Men's Morris
  - Gargoyle Interactive Fiction
  - Game Boy Emulators
  - Telnet Server
- Update Video + Audio Playback to use Google Drive download link
- Update Alpine Kindle Toolkit to use correct QuickAlpine releases link