### PR TITLE
Potential fix for code scanning alert no. 1: Bad HTML filtering regexp

### DIFF
--- a/public/editor.html
+++ b/public/editor.html
@@ -1487,8 +1487,8 @@ function createHTMLStripper() {
           // FIX #17: Safe regex with non-greedy match to prevent catastrophic backtracking
           // Limit iterations and use simpler pattern
           return String(html)
-            .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '') // Remove scripts first
-            .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')   // Remove styles
+            .replace(/<script\b[^<]*(?:(?!<\/script[^>]*>)<[^<]*)*<\/script[^>]*>/gi, '') // Remove scripts first (handles </script foo="bar">)
+            .replace(/<style\b[^<]*(?:(?!<\/style[^>]*>)<[^<]*)*<\/style[^>]*>/gi, '')   // Remove styles (handles </style foo="bar">)
             .replace(/<[^>]{1,1000}>/g, ''); // Remove tags (limit to 1000 chars per tag)
         }
       } catch (err) {


### PR DESCRIPTION
Potential fix for [https://github.com/NemesisHubris/kindlemodshelf.me/security/code-scanning/1](https://github.com/NemesisHubris/kindlemodshelf.me/security/code-scanning/1)

In general, the problem arises because the regex for stripping `<script>` blocks assumes a strictly valid end tag `</script>` with no spaces or additional attributes, while browsers accept more permissive forms. To fix this, the pattern must be updated so that its notion of “end of script tag” matches the browser’s: at least allow optional whitespace before the closing `>`, and ideally tolerate junk attributes after `script` in the end tag. At the same time, we should keep the pattern bounded and non‑catastrophic, because this is already being used as a safe fallback.

The best fix here, without changing existing functionality or structure, is to adjust the two fallback regexes that remove `<script>` and `<style>` tags so that their end tags match `</script` / `</style` followed by any non‑`>` characters, then optional whitespace, then `>`. This covers `</script>`, `</script   >`, and `</script foo="bar">` while staying close to the existing pattern. Concretely, replace `</script>` with `</script[^>]*>` and `</style>` with `</style[^>]*>` in both the fallback branch and the error fallback. No new imports or helpers are needed, and all changes are localized to the regex literals in `public/editor.html` lines 1490–1492 and 1497.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
