### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete multi-character sanitization

### DIFF
--- a/public/editor.html
+++ b/public/editor.html
@@ -1484,17 +1484,14 @@ function createHTMLStripper() {
 
           return text;
         } else {
-          // FIX #17: Safe regex with non-greedy match to prevent catastrophic backtracking
-          // Limit iterations and use simpler pattern
-          return String(html)
-            .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '') // Remove scripts first
-            .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')   // Remove styles
-            .replace(/<[^>]{1,1000}>/g, ''); // Remove tags (limit to 1000 chars per tag)
+          // Fallback when DOMParser is unavailable: remove all angle brackets
+          // to ensure no HTML tags (including <script>) remain.
+          return String(html).replace(/[<>]/g, '');
         }
       } catch (err) {
         console.warn('Error stripping HTML, using safe fallback:', err);
-        // Safe fallback - just remove anything that looks like a tag
-        return String(html).replace(/<[^>]{1,1000}>/g, '');
+        // Safe fallback - remove all angle brackets to strip any HTML tags
+        return String(html).replace(/[<>]/g, '');
       }
     },
 


### PR DESCRIPTION
Potential fix for [https://github.com/NemesisHubris/kindlemodshelf.me/security/code-scanning/3](https://github.com/NemesisHubris/kindlemodshelf.me/security/code-scanning/3)

In general, to fix incomplete multi‑character sanitization you should avoid one‑shot regexes that match large, structured tokens like entire `<script>...</script>` blocks, and instead either (a) use a proper HTML parser/sanitizer library, or (b) apply character‑level sanitization that removes the dangerous characters (`<` and `>`) regardless of how they are arranged. For this file we must not alter overall behavior beyond script/style/tag stripping, so the best approach in the non‑DOMParser branch is to simplify the sanitizer to: convert to string, then remove any `<` or `>` characters. This guarantees that no `<script` (or any other HTML element) can appear in the returned string, eliminating the risk identified by CodeQL.

Concretely, within `strip`’s `else` branch (lines 1487–1493), we will replace the current three‑step replacement chain (script removal, style removal, tag removal) with a single replacement that strips all literal `<` and `>` characters: `return String(html).replace(/[<>]/g, '');`. This keeps the function’s purpose—producing plain text from HTML—while removing the flawed multi‑character script regex entirely. The catch block will also be aligned to use the same `[<>]` replacement instead of the tag‑shaped regex, so the fallback logic can’t reconstruct tags either. No new imports or external libraries are required, and all changes are confined to `public/editor.html` in the shown region.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
