### PR TITLE
Add Simon Tatham puzzle collection page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -564,6 +564,20 @@
         </div>
     </div>
 
+    <div class="card" data-tags="simon tatham portable puzzle collection game puzzles logic native kual booklet hf pw2">
+        <div class="card-header">
+          <div class="card-title">Simon Tatham's Portable Puzzle Collection</div>
+          <div class="card-tags"><span class="tag">Game</span></div>
+        </div>
+        <div class="card-desc">
+          Over 30 classic logic puzzles ported to Kindle, with a launcher, booklet, and KUAL menu support.
+        </div>
+        <div class="card-links">
+          <a href="https://github.com/kbarni/kindlepuzzles/releases/latest" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="simon-tatham-s-portable-puzzle-collection.html">More</a>
+        </div>
+    </div>
+
     <div class="card" data-tags="tictactoe game board kual kindle">
         <div class="card-header">
           <div class="card-title">TicTacToe</div>

--- a/public/simon-tatham-s-portable-puzzle-collection.html
+++ b/public/simon-tatham-s-portable-puzzle-collection.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Simon Tatham's Portable Puzzle Collection for Kindle</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="KindleModShelf">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Simon Tatham's Portable Puzzle Collection for Kindle">
+  <meta name="twitter:description" content="Play more than 30 Simon Tatham puzzle games on your jailbroken Kindle with a native Kindle port, launcher, booklet, and KUAL menu support.">
+  <meta name="description" content="Play more than 30 Simon Tatham puzzle games on your jailbroken Kindle with a native Kindle port, launcher, booklet, and KUAL menu support.">
+  <link rel="canonical" href="https://kindlemodshelf.me/simon-tatham-s-portable-puzzle-collection.html">
+  <link rel="stylesheet" href="style.css?v=3">
+  <meta property="og:title" content="Simon Tatham's Portable Puzzle Collection for Kindle">
+  <meta property="og:description" content="A native Kindle port of Simon Tatham's puzzle collection with over 30 e-ink friendly games.">
+  <meta property="og:url" content="https://kindlemodshelf.me/simon-tatham-s-portable-puzzle-collection.html">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Simon Tatham's Portable Puzzle Collection for Kindle",
+    "operatingSystem": "Kindle OS (jailbroken, HF/PW2 builds)",
+    "applicationCategory": "Game",
+    "description": "A native Kindle port of Simon Tatham's Portable Puzzle Collection with over 30 puzzle games, a launcher app, booklet support, and KUAL menu support.",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "url": "https://kindlemodshelf.me/simon-tatham-s-portable-puzzle-collection.html"
+  }
+  </script>
+  <script src="theme-toggle.js?v=3"></script>
+</head>
+<body>
+  <div class="container">
+    <h1>Simon Tatham's Portable Puzzle Collection</h1>
+
+    <div class="summary">
+      <p><b>Simon Tatham's Portable Puzzle Collection</b> brings more than 30 classic logic puzzles to jailbroken Kindles, adapted for quick e-ink play during reading breaks or long trips.</p>
+    </div>
+
+    <section aria-labelledby="download">
+      <h2 class="section-title" id="download">Download</h2>
+      <div class="card card-desc">
+        <ul>
+          <li><a href="https://github.com/kbarni/kindlepuzzles/releases/latest" target="_blank" rel="noopener">Download the latest Kindle puzzles release</a></li>
+        </ul>
+      </div>
+    </section>
+
+    <section aria-labelledby="features">
+      <h2 class="section-title" id="features">Features</h2>
+      <div class="card card-desc">
+        <ul>
+          <li>More than 30 puzzle games adapted for Kindle</li>
+          <li>Builds for HF and PW2 Kindle architectures</li>
+          <li>Launcher app for selecting games on-device</li>
+          <li>Launch from a booklet or KUAL menu</li>
+          <li>Fast, efficient C implementation with a native GTK interface</li>
+        </ul>
+        <p>Some games from the original collection were removed because they need color, keyboard, or mouse input.</p>
+      </div>
+    </section>
+
+    <section aria-labelledby="requirements">
+      <h2 class="section-title" id="requirements">Requirements</h2>
+      <div class="card card-desc">
+        <ul>
+          <li>Jailbroken Kindle</li>
+          <li>Compatible HF or PW2 Kindle build from the release package</li>
+          <li>KUAL is optional if you use the provided booklet launcher</li>
+        </ul>
+      </div>
+    </section>
+
+    <section aria-labelledby="installation">
+      <h2 class="section-title" id="installation">Installation</h2>
+      <div class="card card-desc">
+        <ol>
+          <li>Download the latest release from the Kindle port page.</li>
+          <li>Extract the downloaded archive on your computer.</li>
+          <li>Copy the extracted files to your Kindle.</li>
+          <li>Start the launcher from your Kindle library using the provided booklet, or launch it from KUAL.</li>
+        </ol>
+      </div>
+    </section>
+
+    <section aria-labelledby="links">
+      <h2 class="section-title" id="links">Links</h2>
+      <div class="card card-desc">
+        <ul>
+          <li><a href="https://www.chiark.greenend.org.uk/~sgtatham/puzzles/" target="_blank" rel="noopener">Original puzzle collection homepage</a></li>
+          <li><a href="https://github.com/kbarni/kindlepuzzles" target="_blank" rel="noopener">Kindle port source code</a></li>
+        </ul>
+      </div>
+    </section>
+
+    <section aria-labelledby="credits">
+      <h2 class="section-title" id="credits">Credits</h2>
+      <div class="card card-desc">
+        <p>Original puzzles by Simon Tatham and contributors. Kindle port by kbarni.</p>
+      </div>
+    </section>
+  </div>
+  <footer class="legal-disclaimer">Educational purposes only. Not affiliated with Amazon. Users responsible for compliance with applicable laws. <a href="https://github.com/NemesisHubris/kindlemodshelf.me" target="_blank" rel="noopener">View Source on GitHub</a> </footer>
+  <script src="navigation.js?v=3"></script>
+</body>
+</html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -375,6 +375,11 @@
     <priority>0.80</priority>
   </url>
   <url>
+    <loc>https://kindlemodshelf.me/simon-tatham-s-portable-puzzle-collection.html</loc>
+    <lastmod>2026-04-28T00:00:00+00:00</lastmod>
+    <priority>0.80</priority>
+  </url>
+  <url>
     <loc>https://kindlemodshelf.me/snake.html</loc>
     <lastmod>2025-12-06T10:43:00+00:00</lastmod>
     <priority>0.80</priority>


### PR DESCRIPTION
Adds the Kindle puzzle collection resource so visitors can find the port, download it, and understand installation requirements from the catalog.