### PR TITLE
Enhanced Release with KUAL Menu Integration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1219,7 +1219,7 @@
           Maintain active Bluetooth connection for headphones and speakers.
         </div>
         <div class="card-links">
-          <a href="https://github.com/imanubdesigner/kindle-bt-keepalive/releases/tag/v1.0.0" class="card-download" target="_blank" rel="noopener">Download</a>
+          <a href="https://github.com/imanubdesigner/kindle-bt-keepalive/releases/" class="card-download" target="_blank" rel="noopener">Download</a>
           <a href="kindle-bt-keepalive.html">More</a>
         </div>
       </div>

--- a/public/kindle-bt-keepalive.html
+++ b/public/kindle-bt-keepalive.html
@@ -50,7 +50,7 @@
       <div class="card card-desc">
         <p>
           <ul>
-            <li><a href="https://github.com/imanubdesigner/kindle-bt-keepalive/releases/tag/v1.0.0">Download Kindle-bt-keepalive V1.0.0</a></li>
+            <li><a href="https://github.com/imanubdesigner/kindle-bt-keepalive/releases/">Download Kindle-bt-keepalive</a></li>
             <li><a href="https://github.com/imanubdesigner/kindle-bt-keepalive">View Repository</a></li>
           </ul>
         </p>


### PR DESCRIPTION
I've updated the release link to point directly to the GitHub Releases page, ensuring users always access the latest version. This update includes a KUAL menu integration that centralizes all functionality, including the ability to read your headphones' MAC address directly from the menu.