### PR TITLE
Sokoban and Kopet added

### DIFF
--- a/public/plugins.html
+++ b/public/plugins.html
@@ -151,6 +151,7 @@
         <li><a href="https://github.com/stefan-misik/game2048.koplugin" target="_blank" rel="noopener"><strong>2048</strong></a> - A game inspired by 2048</li>
         <li><a href="https://github.com/kbarni/sokoban.koplugin" target="_blank" rel="noopener"><strong>Sokoban</strong></a> - Push the crates to the target positions in this addictive classic puzzle game</li>
         <li><a href="https://github.com/omer-faruq/slidepuzzle.koplugin" target="_blank" rel="noopener"><strong>Slide puzzle</strong></a> - A minimal classic sliding-tile puzzle that runs inside KOReader</li>
+        <li><a href="https://github.com/PedroMachado1/kopet.koplugin" target="_blank" rel="noopener"><strong>KoPet</strong></a> - a virtual Tamagochi pet for Koreader</li>
       </ul>
     </div>
 

--- a/public/plugins.html
+++ b/public/plugins.html
@@ -149,6 +149,7 @@
         <li><a href="https://github.com/kbarni/checkers.koplugin" target="_blank" rel="noopener"><strong>Checkers</strong></a> - Play the classic board game against a friend or the AI</li>
         <li><a href="https://github.com/MJCopper/casualkochess.koplugin" target="_blank" rel="noopener"><strong>Casual Chess</strong></a> - Chess with Swordfish engine</li>
         <li><a href="https://github.com/stefan-misik/game2048.koplugin" target="_blank" rel="noopener"><strong>2048</strong></a> - A game inspired by 2048</li>
+        <li><a href="https://github.com/kbarni/sokoban.koplugin" target="_blank" rel="noopener"><strong>Sokoban</strong></a> - Push the crates to the target positions in this addictive classic puzzle game</li>
         <li><a href="https://github.com/omer-faruq/slidepuzzle.koplugin" target="_blank" rel="noopener"><strong>Slide puzzle</strong></a> - A minimal classic sliding-tile puzzle that runs inside KOReader</li>
       </ul>
     </div>


### PR DESCRIPTION
Few more fun plugins added to the Koreader plugin page.

- Sokoban is a classic puzzle game from the '80s that works well on the eink devices. Contains 5 level sets, with over 400 levels.
- Kopet is a Tamagochi-style pet for Koreader. Read pages, care for your pet, collect items, and evolve your companion based on your real reading behavior. (not my work, but I think it deserves to be here)