### PR TITLE
Add 'Fun Recs' recommendations page and surface it in nav/sitemap

### DIFF
--- a/public/announcements.html
+++ b/public/announcements.html
@@ -32,6 +32,12 @@
     <div class="section-title">Latest Updates <small>Newest entries sit at the top</small></div>
 
     <div class="card card-desc">
+      <div class="card-title">05/21/2026 — New Fun Recommendations Page</div>
+      <p>Added a personal recommendations page for favorite projects and apps, including Audiobookshelf, Still, and Calibre-Web.</p>
+      <p><a href="recommendations.html">Check out the recommendations page here.</a></p>
+    </div>
+
+    <div class="card card-desc">
       <div class="card-title">05/02/2026 — Linus Tech Tips Mention</div>
       <p>Linus Tech Tips mentioned Kindle jailbreaking as an option for older devices that are reaching their end of life as Amazon begins to phase out legacy cloud features.</p>
       <p>Check out the timestamped segment here: <a href="https://youtu.be/WbFGK-tjiEY?t=427" target="_blank" rel="noopener">Linus Tech Tips - Kindle Modding Mention</a></p>

--- a/public/index.html
+++ b/public/index.html
@@ -103,6 +103,7 @@
         </div>
         <a href="imageeditor.html" class="nav-link nav-ai">Image Editor</a>
         <a href="announcements.html" class="nav-link">Announcements</a>
+        <a href="recommendations.html" class="nav-link">Fun Recs</a>
         <a href="pagebuilder.html" class="nav-link">Page Builder</a>
         <a href="credits.html" class="nav-link">Credits</a>
         <a href="https://github.com/NemesisHubris/kindlemodshelf.me" class="nav-link" target="_blank" rel="noopener">GitHub</a>

--- a/public/recommendations.html
+++ b/public/recommendations.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Random Recommendations | KindleModShelf</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="KindleModShelf">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Random Recommendations">
+  <meta name="twitter:description" content="A personal shoutout page for favorite open-source projects and apps.">
+  <meta name="description" content="A personal recommendation page from kindlemodshelfguy featuring favorite projects, apps, and self-hosted tools.">
+  <link rel="canonical" href="https://kindlemodshelf.me/recommendations">
+  <link rel="stylesheet" href="style.css?v=3">
+  <meta property="og:title" content="Random Recommendations">
+  <meta property="og:description" content="A personal shoutout page for favorite open-source projects and apps.">
+  <meta property="og:url" content="https://kindlemodshelf.me/recommendations">
+  <meta name="keywords" content="recommendations, open source, self hosting, calibre-web, audiobookshelf, still app">
+  <script src="theme-toggle.js?v=3"></script>
+</head>
+<body>
+  <div class="container container-guide">
+    <h1>Random Recommendations</h1>
+
+    <div class="summary">
+      <p>This page is intentionally off-topic from Kindle modding. It is just a fun shoutout list of projects and apps I personally love and recommend.</p>
+    </div>
+
+    <div class="section-title">Projects &amp; Apps I Love</div>
+
+    <div class="card card-desc">
+      <div class="card-title">Audiobookshelf <small>(Open Source)</small></div>
+      <p>Audiobookshelf is one of my favorite self-hosted apps. It is a great way to manage and stream your audiobook collection with a clean, easy interface.</p>
+      <p>I also love how flexible it is. Depending on your setup, it can fit nicely into some Kindle audio workflows too.</p>
+      <p><a href="https://www.audiobookshelf.org/" target="_blank" rel="noopener">https://www.audiobookshelf.org/</a></p>
+    </div>
+
+    <div class="card card-desc">
+      <div class="card-title">Still (iPhone Audiobookshelf Client) <small>(Not Open Source)</small></div>
+      <p>Still is my favorite iPhone app for Audiobookshelf. The developer is very responsive, and the UI/UX is the best iOS audiobook experience I have used so far.</p>
+      <p>Its free tier already includes the features most people need, including downloads, while some paid alternatives lock basic features behind subscriptions.</p>
+      <p><a href="https://still.宙.space" target="_blank" rel="noopener">https://still.宙.space</a></p>
+    </div>
+
+    <div class="card card-desc">
+      <div class="card-title">Calibre-Web <small>(Open Source)</small></div>
+      <p>Calibre-Web is another project I strongly recommend, especially if you already use Calibre and self-host your library.</p>
+      <p>It feels like having your own Kindle-store-style interface for your personal collection. It also supports OPDS, so lots of reading apps can connect to it directly.</p>
+      <p><a href="https://github.com/janeczku/calibre-web" target="_blank" rel="noopener">https://github.com/janeczku/calibre-web</a></p>
+    </div>
+
+    <div class="card card-desc">
+      <div class="card-title">More to come</div>
+      <p>I will keep adding random favorites here over time whenever I find things worth shouting out.</p>
+    </div>
+  </div>
+
+  <footer class="legal-disclaimer">Educational purposes only. Not affiliated with Amazon. Users responsible for compliance with applicable laws. <a href="https://github.com/NemesisHubris/kindlemodshelf.me" target="_blank" rel="noopener">View Source on GitHub</a></footer>
+  <script src="navigation.js?v=3"></script>
+</body>
+</html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -31,6 +31,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://kindlemodshelf.me/recommendations</loc>
+    <lastmod>2026-05-21</lastmod>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://kindlemodshelf.me/architecture-detector</loc>
     <lastmod>2026-05-02</lastmod>
     <priority>0.8</priority>


### PR DESCRIPTION
### Motivation
- Provide a small, off-topic personal recommendations/shoutout page that reuses existing site layout and styles with no new CSS.
- Make the page discoverable from the homepage and include it in the sitemap and announcements so search and visitors can find it.

### Description
- Added a new page at `public/recommendations.html` containing intro copy and recommendations for Audiobookshelf, Still (iPhone client), and Calibre-Web using existing `.container`/`.card` styles.
- Inserted a `Fun Recs` link into the top navigation in `public/index.html` so the page is reachable from the homepage.
- Added a `https://kindlemodshelf.me/recommendations` entry to `public/sitemap.xml` with `lastmod` set to `2026-05-21`.
- Added an announcement card linking to the new page in `public/announcements.html` and did not introduce any new CSS files or style rules.

### Testing
- Ran `git status --short` to confirm working tree changes and `git diff -- public/index.html public/announcements.html public/sitemap.xml public/recommendations.html` to review diffs; both succeeded.
- Verified the new files and edits by printing `public/recommendations.html` and the updated sections of `public/index.html`, `public/sitemap.xml`, and `public/announcements.html`.
- Attempted an automated full-page screenshot using Playwright, but it failed in this environment due to a missing `playwright` module (no visual screenshot generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0e91df21588327b32f62d10090f736)