### PR TITLE
Frotz added to the koreader plugins section

### DIFF
--- a/public/plugins.html
+++ b/public/plugins.html
@@ -143,6 +143,7 @@
     <div class="section-title">Games &amp; Entertainment</div>
     <div class="card card-desc">
       <ul>
+        <li><a href="https://github.com/kbarni/frotz.koplugin" target="_blank" rel="noopener"><strong>Frotz</strong></a> - Play interactive fiction games</li>
         <li><a href="https://github.com/odrling/connections.koplugin" target="_blank" rel="noopener"><strong>Connections</strong></a> - NYT Connections puzzle game</li>
         <li><a href="https://github.com/omer-faruq/sudoku.koplugin" target="_blank" rel="noopener"><strong>sudoku</strong></a> - Sudoku in KOReader</li>
         <li><a href="https://github.com/maharjanmilan/sudoku.koplugin" target="_blank" rel="noopener"><strong>sudoku non-touch version</strong></a> - Sudoku non-touch version</li>


### PR DESCRIPTION
Frotz is finally complete, so I added it to the Koreader plugins / games&entertainment section.

This plugin allows playing Interactive fiction games from Koreader.