### PR TITLE
Shorten docs, PR/issue-only contribution flow, accurate Page Builder docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,7 +22,7 @@ Our goal: Keep this project safe, friendly, and welcoming for everyone intereste
 
 ## If you see a problem
 
-Ping @kindlemodshelfguy on the [Kindle Modding Discord](https://dsc.gg/kindle-modding).
+Open a GitHub issue. If it's sensitive and you'd rather not post it publicly, email admin@kindlemodshelf.me instead.
 We’ll listen, review, and take action if needed.
 
 ## Enforcement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,6 @@ Last Updated: January 14, 2026
 ## How to Contribute
 
 - GitHub pull request
-- Email: admin@kindlemodshelf.me
-- Discord: @kindlemodshelfguy
 
 ---
 
@@ -59,7 +57,6 @@ Guides may involve jailbreaking, firmware modification, and voiding warranties. 
 
 ## Contact
 
-admin@kindlemodshelf.me
-Discord: @kindlemodshelfguy
+Open a GitHub issue — that's the fastest way to reach us about contributions.
 
 This is a community-led project. Response times vary, but we'll try to get back to you within 30 days.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,7 +21,7 @@ Credit is provided by username/handle on the specific image or page when known.
 
 **Correction Requests:**
 Want your credited name updated or content removed?
-Email: admin@kindlemodshelf.me
+Open a GitHub issue.
 
 This is a community-led project. Response times vary, but we'll try to get back to you within 30 days.
 

--- a/IMAGES.md
+++ b/IMAGES.md
@@ -78,14 +78,9 @@ Example:
 - make sure filenames in `public/images.json` exactly match the real files
 - do not add nested folders inside an author folder if you want them to appear in the gallery
 
-### If You Do Not Want To Use GitHub
+### If You're Not Comfortable Using GitHub Directly
 
-You can still send images directly:
-
-- Email: `admin@kindlemodshelf.me`
-- Discord: `@kindlemodshelfguy`
-
-Include your credited name and images.
+Open a GitHub issue and we can help walk you through the pull request.
 
 ---
 
@@ -129,14 +124,14 @@ This is a community-led project. Response times vary, but we'll try to get back 
 
 ---
 
-Want to update your credited name or provide better versions? Email us.
+Want to update your credited name or provide better versions? Open a GitHub issue.
 
 ---
 
 ## Contact
 
-admin@kindlemodshelf.me
-Discord: @kindlemodshelfguy
+Open a GitHub issue for anything contribution-related.
+For content removal or copyright requests, email: admin@kindlemodshelf.me
 https://kindlemodshelf.me
 
 This is a community-led project. Response times vary, but we'll try to get back to you within 30 days.

--- a/README.md
+++ b/README.md
@@ -16,80 +16,64 @@ You'll find pages for games, apps, mod tools, image galleries, install guides, a
 
 ## Creating Pages with the Page Builder
 
-Use the Page Builder for regular pages.
+Use the Page Builder for regular pages — including editing pages that already exist on the site.
 
-Only skip it if you are editing an existing page or creating a custom page with special behavior, custom layout, gallery logic, app logic, or something else that does not fit the normal site pattern.
+Only skip it if you are creating a custom page with special behavior, custom layout, gallery logic, app logic, or something else that does not fit the normal site pattern.
 
 Visit: [kindlemodshelf.me/pagebuilder.html](https://kindlemodshelf.me/pagebuilder.html)
 
+The Page Builder is a markdown editor, not an HTML editor. You write the page in markdown with a live preview alongside, and export a `.md` file — the site's build step turns that into the actual HTML page.
+
 **What you can do:**
 - Write and format text with bold, italic, underline, links
-- Add sections with titles
-- Embed YouTube videos
-- Add code blocks, banners, and credits
-- Live preview of your page
-- Export as a complete HTML file
+- Insert common blocks (headings, code blocks, banners, credits, embeds) from the slash-command palette
+- Browse and load any existing page on the site to edit it, instead of starting from scratch
+- Live preview of your page as you write
+- Generate the homepage card snippet for your page
+- Export as a `.md` file
 
-**How to create a page:**
+**How to create or edit a page:**
 1. Go to the Page Builder
-2. Choose the normal page layout for the kind of page you are making
-3. Fill in the sections
-4. Click `Export HTML` when done
-5. Click `Copy Index Card` if the page should appear on the homepage
-6. Send the HTML file to us
+2. Start a new page, or click `Browse` to load an existing page's markdown for editing
+3. Write or edit the content
+4. Use the card generator if the page should appear on the homepage
+5. Click `Export` when done to download the `.md` file
+6. Open a pull request adding the file (see below)
 
 ---
 
 ## How to Share Your Page
 
-You have multiple options. Pick whichever is easiest for you:
-
-**Option 1: Pull Request (GitHub)**
-If you know how to use Git:
 1. Fork the repository
-2. Add your HTML file to the project
-3. Update index.html to link to your page
-4. Create a pull request
+2. Add your exported `.md` file to `public/content/`
+3. If it's a new page, add the homepage card snippet (from the Page Builder's card generator) to `index.html`
+4. Open a pull request
 
-**Option 2: Email or Direct Message**
-If GitHub is too complicated:
-1. Create your page with the Page Builder
-2. Export the HTML file
-3. Email it to us or DM @kindlemodshelfguy on Discord
-4. We'll add it to the site for you
-
-Don't worry about naming files, updating sitemap.xml, or any technical stuff. Just send us the file.
+Pull requests are the only way to submit pages — we don't take files by email or DM.
 
 ---
 
 ## Proposing Changes & Reporting Issues
 
-Use GitHub issues to suggest changes, report bugs, or propose new pages. This helps us track and organize feedback.
-
-You can also reach us on the [Kindle Modding Discord](https://dsc.gg/kindle-modding) if you prefer, but GitHub issues are preferred.
+Please always open a [GitHub issue](../../issues) to suggest changes, report bugs, or propose new pages. This keeps feedback tracked and organized in one place.
 
 ---
 
-## Project Structure
-
-- `index.html` – Homepage and navigation
-- `pagebuilder.html` – Page builder tool for creating guides
-- `pagebuilder.js` – Page builder logic
-- `pagebuilder.css` – Page builder styles
-- `style.css` – Shared global styles
-- `sitemap.xml` – Sitemap for search engines
-- `images.json` – Image gallery manifest
-- `/downloads/` – Downloadable assets and scripts
-- `/images/` – Community screensaver images
-
 ## Page Authoring Guide
 
-For the real-world page structure used across `public/*.html`, see `PAGE_FORMAT.md`.
+For the real-world page structure used across `public/*.html`, see [PAGE_FORMAT.md](PAGE_FORMAT.md).
 For most normal pages, the Page Builder is the recommended starting point.
 
 ## Image Submission Guide
 
-If you want to add your own screenshots or Kindle-related images, see `IMAGES.md`.
+If you want to add your own screenshots or Kindle-related images, see [IMAGES.md](IMAGES.md).
+
+## Contributing, License & More
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) – contribution guidelines
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) – community expectations
+- [CONTRIBUTORS.md](CONTRIBUTORS.md) – project contributors
+- [LICENSE.md](LICENSE.md) – project license
 
 ---
 


### PR DESCRIPTION
## Summary
- **PR/issue-only policy**: pull requests are the only way to submit pages/images, GitHub issues are the default for everything else (bugs, corrections, feedback). Removed all the old email/DM submission paths.
- **Accurate Page Builder docs**: it's a markdown editor (export `.md`, the build step turns it into HTML) that can also browse/edit existing pages — not the old HTML-export description.
- **Big shortening pass**: cut ~360 lines across README, CONTRIBUTING, CODE_OF_CONDUCT, CONTRIBUTORS, IMAGES, PAGE_FORMAT. Mainly removed duplicated contact/boilerplate blocks (IMAGES.md had the same "here's how to reach us" text in three different sections) and a "Short Version" in PAGE_FORMAT.md that just restated the whole file again. Licensing terms in CONTRIBUTING.md/LICENSE.md were tightened in wording only — no substantive changes.
- Dropped the README's internal "Project Structure" file/path listing.
- Added cross-links between README and CONTRIBUTING/CODE_OF_CONDUCT/CONTRIBUTORS/LICENSE/PAGE_FORMAT/IMAGES.

## Kept as private-email fallbacks (not GitHub issue)
- CODE_OF_CONDUCT.md conduct/harassment reports
- IMAGES.md copyright/takedown requests

Both cases involve reports someone may not want made public; issue is still the stated default in both places.

## Test plan
- [ ] Docs-only change — read through rendered files on GitHub for formatting/link correctness